### PR TITLE
Proper texture filenames

### DIFF
--- a/demo/code.js
+++ b/demo/code.js
@@ -22,8 +22,14 @@ function showNodeInfo( node, root )
 		info = " Mesh: <span class='id2'>" + node.mesh + "</span>";
 	if(node.light)
 		info += " Light: " + node.light.type;
-	if(node.camera)
-		info += " Camera: FOV " + node.camera.fov.toFixed(2);
+	if(node.camera){
+		if (node.camera.fov)
+			info += " Camera: FOV " + node.camera.fov.toFixed(2);
+		else if (node.camera.yfov)
+			info += " Camera: YFOV " + node.camera.yfov.toFixed(2);
+		else if (node.camera.xfov)
+			info += " Camera: XFOV " + node.camera.xfov.toFixed(2);
+	}
 	if(node.materials)
 	{
 		info += " <br/>Materials: ";
@@ -72,7 +78,7 @@ function showSceneInfo(scene)
 	for(var i in scene.materials )
 	{
 		var mat = scene.materials[i];
-		log("<li><span class='id2'>" + i + "</span>: <span class='color'>" + (mat.diffuse ? "DIFFUSE: " + getColorString(mat.diffuse) : "NO COLOR") + "</span></li>");
+		log("<li><span class='id2'>" + i + "</span>: <span class='color'>" + (mat.diffuse ? "DIFFUSE: " + getColorString(mat.diffuse) : "NO COLOR") + "</span> : <span class='color'>" + (mat.textures.diffuse ? "DIFFUSE_TEX: " + mat.textures.diffuse.map_id : "NO DIFFUSE TEX") + "</span></li>");
 	}
 
 	log("<h2>Images</h2>");
@@ -92,8 +98,8 @@ function init()
 
 	elem.querySelector("button").addEventListener("click", function() {
 		onStartParsing();
-		Collada.loadInWorker("teapots.DAE", onParsed );
-		//Collada.load("teapots.DAE", onParsed ); //use this for worker
+		//Collada.loadInWorker("teapots.DAE", onParsed );
+		Collada.load("teapots.DAE", onParsed ); //use this for worker
 	});
 
 	//droping files 

--- a/src/collada.js
+++ b/src/collada.js
@@ -622,7 +622,7 @@ global.Collada = {
 		return null;
 	},
 
-	readMaterial: function(url)
+		readMaterial: function(url)
 	{
 		var xmlmaterial = this.querySelectorAndId( this._xmlroot, "library_materials material", url );
 		if(!xmlmaterial)
@@ -643,7 +643,32 @@ global.Collada = {
 		if(!xmltechnique) 
 			return null;
 
+		//get newparams and convert to js object
+		var xmlnewparams = xmleffects.querySelectorAll("newparam");
+		var newparams = {}
+		for (var i = 0; i < xmlnewparams.length; i++) {
+
+			var init_from = xmlnewparams[i].querySelector("init_from");
+			var parent;
+			if (init_from)
+				parent = init_from.innerHTML;
+			else {
+				var source = xmlnewparams[i].querySelector("source");
+				parent = source.innerHTML;
+			}
+
+			newparams[xmlnewparams[i].getAttribute("sid")] = {
+				parent: parent
+			};
+		}
+
+
+
 		var material = {};
+
+		//read the images here because we need to access them to assign texture names
+		var images = this.readImages(this._xmlroot);
+
 
 		var xmlphong = xmltechnique.querySelector("phong");
 		if(!xmlphong) 
@@ -691,6 +716,17 @@ global.Collada = {
 				if(!map_id)
 					continue;
 
+				// if map_id is not a filename, lets go and look for it.
+				if (map_id.indexOf('.') === -1){
+					//check effect parents
+					map_id = this.getParentParam(newparams, map_id);
+
+					if (images[map_id])
+						map_id = images[map_id].path;
+				}
+
+				//now get the texture filename from images
+
 				var map_info = { map_id: map_id };
 				var uvs = xmlparam_value.getAttribute("texcoord");
 				map_info.uvs = uvs;
@@ -700,6 +736,16 @@ global.Collada = {
 
 		material.object_type = "Material";
 		return material;
+	},
+
+	getParentParam: function(newparams, param) {
+		if (!newparams[param])
+			return param;
+
+		if (newparams[param].parent)
+			return this.getParentParam(newparams, newparams[param].parent)
+		else
+			return param;
 	},
 
 	readLight: function(node, url)


### PR DESCRIPTION
These changes correctly look up the texture filename by following the path of ids in the newparams element. The map_id property of the texture of the material now contains the relative path of the texture filename.
